### PR TITLE
Drop cantera channel from the conda env file

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -1,7 +1,6 @@
 name: test-conda-env
 channels:
 - conda-forge
-- cantera/label/dev
 - nodefaults
 
 dependencies:


### PR DESCRIPTION
Cantera is now in conda forge :tada: